### PR TITLE
Fixed item on cursor swapping bug

### DIFF
--- a/Outfitter/Documentation/RevisionHistory.txt
+++ b/Outfitter/Documentation/RevisionHistory.txt
@@ -11,6 +11,13 @@ Judgement Legplates)
 Generating an outfit will not find items in the main bank slots
 -------------------------------------------
 
+Version 1.4.1 Changes
+
+- Fixed item swapping bug. Holding an item from your bags in your cursor while changing should no 
+  longer swap that item with an item intended to be equiped. For example: Mounting up and grabbing 
+  something from your bags before you are done, resulting in a swap between whatever you took 
+  with a carrot on a stick.
+
 Version 1.4 Changes
 
 - Special Occassion outfit added for mages when evocating

--- a/Outfitter/OutfitterStrings.lua
+++ b/Outfitter/OutfitterStrings.lua
@@ -1,4 +1,4 @@
-Outfitter_cVersion = "1.4";
+Outfitter_cVersion = "1.4.1";
 
 Outfitter_cTitle = "Outfitter";
 Outfitter_cTitleVersion = Outfitter_cTitle.." "..Outfitter_cVersion;
@@ -226,9 +226,9 @@ Outfitter_cUnequipOutfitMessageFormat = "Outfitter: %s unequipped";
 Outfitter_cAboutTitle = "About Outfitter";
 Outfitter_cAuthor = "Designed and written by John Stephen";
 Outfitter_cTestersTitle = "Beta Testers";
-Outfitter_cTestersNames = "Airmid, Desiree, Fizzlebang, Harper, Kallah and Sumitra";
+Outfitter_cTestersNames = "Airmid, Desiree, Fizzlebang, Harper, Kallah and Sumitra. (Squishie v1.4.1)";
 Outfitter_cSpecialThanksTitle = "Special thanks for their support to";
-Outfitter_cSpecialThanksNames = "Brian, Dave, Glenn, Leah, Mark, The Mighty Pol, SFC and Forge";
+Outfitter_cSpecialThanksNames = "Brian, Dave, Glenn, Leah, Mark, The Mighty Pol, SFC and Forge. (Squishie v1.4.1)";
 Outfitter_cGuildURL = "http://www.starfleetclan.com";
 Outfitter_cGuildURL2 = "http://www.forgeguild.com";
 

--- a/Outfitter/OutfitterStrings_de.lua
+++ b/Outfitter/OutfitterStrings_de.lua
@@ -205,9 +205,9 @@ if GetLocale() == "deDE" then
 	Outfitter_cAboutTitle = "\195\188ber Outfitter";
 	Outfitter_cAuthor = "Gestaltet und geschrieben von John Stephen";
 	Outfitter_cTestersTitle = "Beta Tester";
-	Outfitter_cTestersNames = "Airmid, Desiree, Fizzlebang, Harper, Kallah und Sumitra";
+	Outfitter_cTestersNames = "Airmid, Desiree, Fizzlebang, Harper, Kallah und Sumitra. (Squishie v1.4.1)";
 	Outfitter_cSpecialThanksTitle = "Besonderen Dank f\195\188r ihre Unterst\195\188tzung geht an";
-	Outfitter_cSpecialThanksNames = "Brian, Dave, Glenn, Leah, Mark, The Mighty Pol, SFC und Forge";
+	Outfitter_cSpecialThanksNames = "Brian, Dave, Glenn, Leah, Mark, The Mighty Pol, SFC und Forge. (Squishie v1.4.1)";
 	Outfitter_cGuildURL = "http://www.starfleetclan.com";
 	Outfitter_cGuildURL2 = "http://www.forgeguild.com";
 

--- a/Outfitter/OutfitterStrings_fr.lua
+++ b/Outfitter/OutfitterStrings_fr.lua
@@ -215,9 +215,9 @@ if GetLocale() == "frFR" then
 	Outfitter_cAboutTitle = "A propos d\226\128\153Outfitter";
 	Outfitter_cAuthor = "Designed and written by Baylord of Thunderlord";
 	Outfitter_cTestersTitle = "Beta Testers";
-	Outfitter_cTestersNames = "Airmid, Desiree, Fizzlebang, Harper, Kallah and Sumitra";
+	Outfitter_cTestersNames = "Airmid, Desiree, Fizzlebang, Harper, Kallah and Sumitra. (Squishie v1.4.1)";
 	Outfitter_cSpecialThanksTitle = "Special thanks for their support to";
-	Outfitter_cSpecialThanksNames = "Brian, Dave, Glenn, Leah, Mark, The Mighty Pol, SFC and Forge";
+	Outfitter_cSpecialThanksNames = "Brian, Dave, Glenn, Leah, Mark, The Mighty Pol, SFC and Forge. (Squishie v1.4.1)";
 	Outfitter_cGuildURL = "http://www.starfleetclan.com";
 	Outfitter_cGuildURL2 = "http://www.forgeguild.com";
 

--- a/Outfitter/OutfitterStrings_kr.lua
+++ b/Outfitter/OutfitterStrings_kr.lua
@@ -220,9 +220,9 @@ if GetLocale() == "koKR" then
 	Outfitter_cAboutTitle = "Outfitter 정보";
 	Outfitter_cAuthor = "Designed and written by John Stephen";
 	Outfitter_cTestersTitle = "Beta Testers";
-	Outfitter_cTestersNames = "Airmid, Desiree, Fizzlebang, Harper, Kallah and Sumitra";
+	Outfitter_cTestersNames = "Airmid, Desiree, Fizzlebang, Harper, Kallah and Sumitra. (Squishie v1.4.1)";
 	Outfitter_cSpecialThanksTitle = "Special thanks for their support to";
-	Outfitter_cSpecialThanksNames = "Brian, Dave, Glenn, Leah, Mark, The Mighty Pol, SFC and Forge";
+	Outfitter_cSpecialThanksNames = "Brian, Dave, Glenn, Leah, Mark, The Mighty Pol, SFC and Forge. (Squishie v1.4.1)";
 	Outfitter_cGuildURL = "http://www.starfleetclan.com";
 	Outfitter_cGuildURL2 = "http://www.forgeguild.com";
 


### PR DESCRIPTION
Fixed item swapping bug. Holding an item from your bags in your cursor while changing should no 
longer swap that item with an item intended to be equipped. For example: Mounting up and grabbing 
something from your bags before you are done, resulting in a swap between whatever you took 
with a carrot on a stick.